### PR TITLE
#3: Fix multiple browsers!

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,25 +2,25 @@ exclude: 'docs'
 fail_fast: false
 repos:
 - repo: https://github.com/psf/black
-  rev: 22.12.0
+  rev: 23.10.1
   hooks:
   - id: black
-    language_version: python3.11
+    language_version: python3.12
 - repo: https://github.com/timothycrosley/isort
-  rev: 5.11.4
+  rev: 5.12.0
   hooks:
   - id: isort
-    language_version: python3.11
+    language_version: python3.12
 - repo: https://github.com/PyCQA/flake8
-  rev: 6.0.0
+  rev: 6.1.0
   hooks:
   - id: flake8
-    language_version: python3.11
+    language_version: python3.12
 - repo: https://github.com/pre-commit/mirrors-mypy
-  rev: v0.991
+  rev: v1.6.1
   hooks:
   - id: mypy
-    language_version: python3.11
+    language_version: python3.12
 - repo: local
   hooks:
   - id: pylint

--- a/screenpy_playwright/abilities/browse_the_web_synchronously.py
+++ b/screenpy_playwright/abilities/browse_the_web_synchronously.py
@@ -39,7 +39,8 @@ class BrowseTheWebSynchronously:
         browser: Browser,
     ) -> SelfBrowseTheWebSynchronously:
         """Supply a pre-defined Playwright browser to use."""
-        return cls(playwright, browser)
+        cls.playwright = playwright
+        return cls(browser)
 
     @classmethod
     def using_firefox(
@@ -48,26 +49,25 @@ class BrowseTheWebSynchronously:
         """Use a synchronous Firefox browser."""
         if cls.playwright is None:
             cls.playwright = sync_playwright().start()
-        browser = cls.playwright.firefox.launch()
-        return cls(cls.playwright, browser)
+        return cls(cls.playwright.firefox.launch())
 
     @classmethod
     def using_chromium(
         cls: type[SelfBrowseTheWebSynchronously],
     ) -> SelfBrowseTheWebSynchronously:
         """Use a synchronous Chromium (i.e. Chrome, Edge, Opera, etc.) browser."""
-        cls.playwright = sync_playwright().start()
-        browser = cls.playwright.chromium.launch()
-        return cls(cls.playwright, browser)
+        if cls.playwright is None:
+            cls.playwright = sync_playwright().start()
+        return cls(cls.playwright.chromium.launch())
 
     @classmethod
     def using_webkit(
         cls: type[SelfBrowseTheWebSynchronously],
     ) -> "BrowseTheWebSynchronously":
         """Use a synchronous WebKit (i.e. Safari, etc.) browser."""
-        cls.playwright = sync_playwright().start()
-        browser = cls.playwright.webkit.launch()
-        return cls(cls.playwright, browser)
+        if cls.playwright is None:
+            cls.playwright = sync_playwright().start()
+        return cls(cls.playwright.webkit.launch())
 
     def forget(self: SelfBrowseTheWebSynchronously) -> None:
         """Forget everything you knew about being a playwright."""
@@ -77,12 +77,8 @@ class BrowseTheWebSynchronously:
 
     def __init__(
         self: SelfBrowseTheWebSynchronously,
-        playwright: Playwright,
         browser: Browser,
     ) -> None:
-        if self.__class__.playwright is None:
-            self.__class__.playwright = playwright
-        self.playwright = playwright
         self.browser = browser
         self.current_page: Page = None
         self.pages: Page = []

--- a/screenpy_playwright/abilities/browse_the_web_synchronously.py
+++ b/screenpy_playwright/abilities/browse_the_web_synchronously.py
@@ -7,7 +7,7 @@ from playwright.sync_api import sync_playwright
 if TYPE_CHECKING:
     from typing import TypeVar
 
-    from playwright.sync_api import Browser, Page, Playwright
+    from playwright.sync_api import Browser, BrowserContext, Page, Playwright
 
     SelfBrowseTheWebSynchronously = TypeVar(
         "SelfBrowseTheWebSynchronously", bound="BrowseTheWebSynchronously"
@@ -36,7 +36,7 @@ class BrowseTheWebSynchronously:
     def using(
         cls: type[SelfBrowseTheWebSynchronously],
         playwright: Playwright,
-        browser: Browser,
+        browser: Browser | BrowserContext,
     ) -> SelfBrowseTheWebSynchronously:
         """Supply a pre-defined Playwright browser to use."""
         cls.playwright = playwright
@@ -77,7 +77,7 @@ class BrowseTheWebSynchronously:
 
     def __init__(
         self: SelfBrowseTheWebSynchronously,
-        browser: Browser,
+        browser: Browser | BrowserContext,
     ) -> None:
         self.browser = browser
         self.current_page: Page = None

--- a/screenpy_playwright/abilities/browse_the_web_synchronously.py
+++ b/screenpy_playwright/abilities/browse_the_web_synchronously.py
@@ -1,4 +1,17 @@
-from playwright.sync_api import sync_playwright, Playwright, Browser
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from playwright.sync_api import sync_playwright
+
+if TYPE_CHECKING:
+    from typing import TypeVar
+
+    from playwright.sync_api import Browser, Page, Playwright
+
+    SelfBrowseTheWebSynchronously = TypeVar(
+        "SelfBrowseTheWebSynchronously", bound="BrowseTheWebSynchronously"
+    )
 
 
 class BrowseTheWebSynchronously:
@@ -17,40 +30,59 @@ class BrowseTheWebSynchronously:
         )
     """
 
-    @staticmethod
-    def using(playwright: Playwright, browser: Browser) -> "BrowseTheWebSynchronously":
+    playwright: Playwright = None
+
+    @classmethod
+    def using(
+        cls: type[SelfBrowseTheWebSynchronously],
+        playwright: Playwright,
+        browser: Browser,
+    ) -> SelfBrowseTheWebSynchronously:
         """Supply a pre-defined Playwright browser to use."""
-        return BrowseTheWebSynchronously(playwright, browser)
+        return cls(playwright, browser)
 
-    @staticmethod
-    def using_firefox() -> "BrowseTheWebSynchronously":
+    @classmethod
+    def using_firefox(
+        cls: type[SelfBrowseTheWebSynchronously],
+    ) -> SelfBrowseTheWebSynchronously:
         """Use a synchronous Firefox browser."""
-        playwright = sync_playwright().start()
-        browser = playwright.firefox.launch()
-        return BrowseTheWebSynchronously(playwright, browser)
+        if cls.playwright is None:
+            cls.playwright = sync_playwright().start()
+        browser = cls.playwright.firefox.launch()
+        return cls(cls.playwright, browser)
 
-    @staticmethod
-    def using_chromium() -> "BrowseTheWebSynchronously":
+    @classmethod
+    def using_chromium(
+        cls: type[SelfBrowseTheWebSynchronously],
+    ) -> SelfBrowseTheWebSynchronously:
         """Use a synchronous Chromium (i.e. Chrome, Edge, Opera, etc.) browser."""
-        playwright = sync_playwright().start()
-        browser = playwright.chromium.launch()
-        return BrowseTheWebSynchronously(playwright, browser)
+        cls.playwright = sync_playwright().start()
+        browser = cls.playwright.chromium.launch()
+        return cls(cls.playwright, browser)
 
-    @staticmethod
-    def using_webkit() -> "BrowseTheWebSynchronously":
+    @classmethod
+    def using_webkit(
+        cls: type[SelfBrowseTheWebSynchronously],
+    ) -> "BrowseTheWebSynchronously":
         """Use a synchronous WebKit (i.e. Safari, etc.) browser."""
-        playwright = sync_playwright().start()
-        browser = playwright.webkit.launch()
-        return BrowseTheWebSynchronously(playwright, browser)
+        cls.playwright = sync_playwright().start()
+        browser = cls.playwright.webkit.launch()
+        return cls(cls.playwright, browser)
 
-    def forget(self) -> None:
+    def forget(self: SelfBrowseTheWebSynchronously) -> None:
         """Forget everything you knew about being a playwright."""
         self.browser.close()
-        if self.playwright:
-            self.playwright.stop()
+        self.playwright.stop()
+        self.__class__.playwright = None
 
-    def __init__(self, playwright: Playwright, browser: Browser) -> None:
+    def __init__(
+        self: SelfBrowseTheWebSynchronously,
+        playwright: Playwright,
+        browser: Browser,
+    ) -> None:
+        if self.__class__.playwright is None:
+            self.__class__.playwright = playwright
         self.playwright = playwright
         self.browser = browser
-        self.current_page = None
-        self.pages = []
+        self.current_page: Page = None
+        self.pages: Page = []

--- a/screenpy_playwright/target.py
+++ b/screenpy_playwright/target.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
 
-from typing import Optional
-
-from playwright.sync_api import Locator
-from screenpy import Actor
+from typing import TYPE_CHECKING, Optional
 
 from .abilities import BrowseTheWebSynchronously
 from .exceptions import TargetingError
+
+if TYPE_CHECKING:
+    from playwright.sync_api import Locator
+    from screenpy import Actor
 
 
 class Target:

--- a/screenpy_playwright/target.py
+++ b/screenpy_playwright/target.py
@@ -1,7 +1,9 @@
+from __future__ import annotations
+
 from typing import Optional
 
-from screenpy import Actor
 from playwright.sync_api import Locator
+from screenpy import Actor
 
 from .abilities import BrowseTheWebSynchronously
 from .exceptions import TargetingError
@@ -22,6 +24,8 @@ class Target:
 
         Target().located_by("#enter-todo-field")
     """
+
+    locator: str | None
 
     @staticmethod
     def the(name: str) -> "Target":

--- a/tests/test_abilities.py
+++ b/tests/test_abilities.py
@@ -1,13 +1,56 @@
+from unittest import mock
+
+import pytest
+from playwright.sync_api import Browser, Playwright
 from screenpy.protocols import Forgettable
 
 from screenpy_playwright.abilities import BrowseTheWebSynchronously
 
 
 class TestBrowseTheWebSynchronously:
-    def test_can_be_instantiated(self):
-        b = BrowseTheWebSynchronously.using(None, None)
+    mock_path = "screenpy_playwright.abilities.browse_the_web_synchronously"
 
-        assert isinstance(b, BrowseTheWebSynchronously)
+    @pytest.fixture(scope="class", autouse=True)
+    def clean_up_ability(self):
+        """Reset the class's playwright attribute to None."""
+        yield
+        BrowseTheWebSynchronously.playwright = None
+
+    def test_can_be_instantiated(self):
+        btws = BrowseTheWebSynchronously.using(None, None)
+
+        assert isinstance(btws, BrowseTheWebSynchronously)
 
     def test_implements_protocol(self):
         assert isinstance(BrowseTheWebSynchronously(None, None), Forgettable)
+
+    def test_sets_class_attribute(self):
+        BrowseTheWebSynchronously.playwright = None
+        mock_playwright = mock.MagicMock(spec=Playwright)
+        mock_browser = mock.MagicMock(spec=Browser)
+
+        BrowseTheWebSynchronously.using(mock_playwright, mock_browser)
+
+        try:
+            assert BrowseTheWebSynchronously.playwright is mock_playwright
+        finally:
+            # teardown
+            BrowseTheWebSynchronously.playwright = None
+
+    def test_can_have_separate_instance_attribute(self):
+        mock_playwright1 = mock.MagicMock(spec=Playwright)
+        mock_playwright2 = mock.MagicMock(spec=Playwright)
+        mock_browser = mock.MagicMock(spec=Browser)
+        mock_sync_playwright = mock.MagicMock()
+        mock_sync_playwright.return_value.start.return_value = mock_playwright1
+
+        with mock.patch(f"{self.mock_path}.sync_playwright", mock_sync_playwright):
+            BrowseTheWebSynchronously.using_firefox()  # sets class playwright
+            btws = BrowseTheWebSynchronously.using(mock_playwright2, mock_browser)
+
+        try:
+            assert BrowseTheWebSynchronously.playwright is mock_playwright1
+            assert btws.playwright is mock_playwright2
+        finally:
+            # teardown
+            BrowseTheWebSynchronously.playwright = None

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py37,py38,py39,py310
+envlist = py38,py39,py310,py311,py312
 
 [testenv]
 deps =


### PR DESCRIPTION
Thanks to Victor on the Indie Testing Community slack, we found out that if you try to give multiple Actors the Ability to `BrowseTheWebSynchronously`, we get an error from Playwright about using it incorrectly. And of course we were—we were trying to start two `playwright` instances, which apparently it does not like!

This PR fixes this problem by storing the active Playwright instance in the Ability. If we need more browsers, we just get them from the active Playwright instance instead of trying to spin up a new one. 👍 