### PR TITLE
Support multiple Actors.

### DIFF
--- a/screenpy_playwright/abilities/browse_the_web_synchronously.py
+++ b/screenpy_playwright/abilities/browse_the_web_synchronously.py
@@ -7,13 +7,8 @@ from typing import TYPE_CHECKING
 from playwright.sync_api import sync_playwright
 
 if TYPE_CHECKING:
-    from typing import TypeVar
-
     from playwright.sync_api import Browser, BrowserContext, Page, Playwright
-
-    SelfBrowseTheWebSynchronously = TypeVar(
-        "SelfBrowseTheWebSynchronously", bound="BrowseTheWebSynchronously"
-    )
+    from typing_extensions import Self
 
 
 class BrowseTheWebSynchronously:
@@ -38,18 +33,18 @@ class BrowseTheWebSynchronously:
 
     @classmethod
     def using(
-        cls: type[SelfBrowseTheWebSynchronously],
+        cls,
         playwright: Playwright,
         browser: Browser | BrowserContext,
-    ) -> SelfBrowseTheWebSynchronously:
+    ) -> Self:
         """Supply a pre-defined Playwright browser to use."""
         cls.playwright = playwright
         return cls(browser)
 
     @classmethod
     def using_firefox(
-        cls: type[SelfBrowseTheWebSynchronously],
-    ) -> SelfBrowseTheWebSynchronously:
+        cls,
+    ) -> Self:
         """Use a synchronous Firefox browser."""
         if cls.playwright is None:
             cls.playwright = sync_playwright().start()
@@ -57,8 +52,8 @@ class BrowseTheWebSynchronously:
 
     @classmethod
     def using_chromium(
-        cls: type[SelfBrowseTheWebSynchronously],
-    ) -> SelfBrowseTheWebSynchronously:
+        cls,
+    ) -> Self:
         """Use a synchronous Chromium (i.e. Chrome, Edge, Opera, etc.) browser."""
         if cls.playwright is None:
             cls.playwright = sync_playwright().start()
@@ -66,22 +61,19 @@ class BrowseTheWebSynchronously:
 
     @classmethod
     def using_webkit(
-        cls: type[SelfBrowseTheWebSynchronously],
+        cls,
     ) -> BrowseTheWebSynchronously:
         """Use a synchronous WebKit (i.e. Safari, etc.) browser."""
         if cls.playwright is None:
             cls.playwright = sync_playwright().start()
         return cls(cls.playwright.webkit.launch())
 
-    def forget(self: SelfBrowseTheWebSynchronously) -> None:
+    def forget(self: Self) -> None:
         """Forget everything you knew about being a playwright."""
         self.browser.close()
-        if self.playwright:
-            self.playwright.stop()
-        self.__class__.playwright = None
 
     def __init__(
-        self: SelfBrowseTheWebSynchronously,
+        self,
         browser: Browser | BrowserContext,
     ) -> None:
         self.browser = browser

--- a/tests/test_abilities.py
+++ b/tests/test_abilities.py
@@ -56,3 +56,12 @@ class TestBrowseTheWebSynchronously:
         assert mock_playwright.chromium.launch.call_count == 1
         assert mock_playwright.firefox.launch.call_count == 1
         assert mock_playwright.webkit.launch.call_count == 1
+
+    def test_forget_does_not_clear_playwright(self) -> None:
+        mock_playwright, mock_browser = get_mocked_playwright_and_browser()
+        btws = BrowseTheWebSynchronously.using(mock_playwright, mock_browser)
+
+        btws.forget()
+
+        assert BrowseTheWebSynchronously.playwright is mock_playwright
+        assert mock_browser.close.call_count == 1


### PR DESCRIPTION
While i was writing a test that has two Actors attempt to get on a call together, i noticed only one of the Actors was successfully tearing down and taking screenshots. The second Actor would get an error from Playwright, saying that the Playwright instance was already closed.

Well of course it was, that first Actor would do `self.playwright.close()` when their `BrowseTheWebSynchronously` ability was forgotten!

This PR takes out that call. Now that i'm more familiar with how Playwright works, keeping the Playwright instance active makes a lot more sense, especially in the context of the `pytest` fixtures Playwright provides in their plugin.