### PR TITLE
Add an easier message to read when errors occur.

### DIFF
--- a/screenpy_playwright/actions/click.py
+++ b/screenpy_playwright/actions/click.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Sequence, TypedDict
 
-from screenpy.pacing import beat
+from playwright.sync_api import Error as PlaywrightError
+from screenpy import DeliveryError, beat
 
 if TYPE_CHECKING:
     from playwright.sync_api import Position
@@ -62,7 +63,14 @@ class Click:
     @beat("{} clicks on the {target}.")
     def perform_as(self, the_actor: Actor) -> None:
         """Direct the Actor to click on the element."""
-        self.target.found_by(the_actor).click(**self.kwargs)
+        try:
+            self.target.found_by(the_actor).click(**self.kwargs)
+        except PlaywrightError as e:
+            msg = (
+                f"{the_actor} encountered an issue while attempting to click "
+                f"{self.target}: {e.__class__.__name__}"
+            )
+            raise DeliveryError(msg) from e
 
     def __init__(self, target: Target, **kwargs: Unpack[ClickTypes]) -> None:
         self.target = target

--- a/screenpy_playwright/actions/enter.py
+++ b/screenpy_playwright/actions/enter.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, TypedDict
 
-from screenpy.exceptions import UnableToAct
-from screenpy.pacing import beat
+from playwright.sync_api import Error as PlaywrightError
+from screenpy import DeliveryError, UnableToAct, beat
 
 if TYPE_CHECKING:
     from screenpy import Actor
@@ -87,7 +87,14 @@ class Enter:
             )
             raise UnableToAct(msg)
 
-        self.target.found_by(the_actor).fill(self.text, **self.kwargs)
+        try:
+            self.target.found_by(the_actor).fill(self.text, **self.kwargs)
+        except PlaywrightError as e:
+            msg = (
+                f"{the_actor} encountered an issue while attempting to enter text into "
+                f"{self.target}: {e.__class__.__name__}"
+            )
+            raise DeliveryError(msg) from e
 
     def __init__(
         self, text: str, *, mask: bool = False, **kwargs: Unpack[EnterTypes]

--- a/screenpy_playwright/actions/open.py
+++ b/screenpy_playwright/actions/open.py
@@ -5,7 +5,8 @@ from __future__ import annotations
 import os
 from typing import TYPE_CHECKING, TypedDict
 
-from screenpy.pacing import beat
+from playwright.sync_api import Error as PlaywrightError
+from screenpy import DeliveryError, beat
 
 from ..abilities import BrowseTheWebSynchronously
 
@@ -56,7 +57,15 @@ class Open:
         """Direct the actor to Open a webpage."""
         browse_the_web = the_actor.ability_to(BrowseTheWebSynchronously)
         page = browse_the_web.browser.new_page()
-        page.goto(self.url, **self.kwargs)
+        try:
+            page.goto(self.url, **self.kwargs)
+        except PlaywrightError as e:
+            msg = (
+                f"{the_actor} encountered an issue while attempting to go to "
+                f"{self.url}: {e.__class__.__name__}"
+            )
+            raise DeliveryError(msg) from e
+
         browse_the_web.current_page = page
         browse_the_web.pages.append(page)
 

--- a/screenpy_playwright/actions/refresh_the_page.py
+++ b/screenpy_playwright/actions/refresh_the_page.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Literal, TypedDict
 
-from screenpy import beat
+from playwright.sync_api import Error as PlaywrightError
+from screenpy import DeliveryError, beat
 
 from screenpy_playwright.abilities import BrowseTheWebSynchronously
 
@@ -45,4 +46,11 @@ class RefreshThePage:
     def perform_as(self, the_actor: Actor) -> None:
         """Direct the Actor to refresh the page."""
         page = the_actor.ability_to(BrowseTheWebSynchronously).current_page
-        page.reload(**self.kwargs)
+        try:
+            page.reload(**self.kwargs)
+        except PlaywrightError as e:
+            msg = (
+                f"{the_actor} encountered an issue while attempting to "
+                f"refresh the page: {e.__class__.__name__}"
+            )
+            raise DeliveryError(msg) from e

--- a/screenpy_playwright/actions/save_screenshot.py
+++ b/screenpy_playwright/actions/save_screenshot.py
@@ -89,6 +89,7 @@ class SaveScreenshot:
         if current_page is None:
             msg = "No page has been opened! Cannot save a screenshot."
             raise UnableToAct(msg)
+
         try:
             screenshot = current_page.screenshot(path=self.path)
         except PlaywrightError as e:

--- a/screenpy_playwright/actions/save_screenshot.py
+++ b/screenpy_playwright/actions/save_screenshot.py
@@ -6,7 +6,8 @@ import os
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
-from screenpy import AttachTheFile, UnableToAct, beat
+from playwright.sync_api import Error as PlaywrightError
+from screenpy import AttachTheFile, DeliveryError, UnableToAct, beat
 
 from ..abilities import BrowseTheWebSynchronously
 
@@ -88,8 +89,15 @@ class SaveScreenshot:
         if current_page is None:
             msg = "No page has been opened! Cannot save a screenshot."
             raise UnableToAct(msg)
+        try:
+            screenshot = current_page.screenshot(path=self.path)
+        except PlaywrightError as e:
+            msg = (
+                f"{the_actor} encountered an issue while attempting to "
+                f"save a screenshot: {e.__class__.__name__}"
+            )
+            raise DeliveryError(msg) from e
 
-        screenshot = current_page.screenshot(path=self.path)
         Path(self.path).write_bytes(screenshot)
 
         if self.attach_kwargs is not None:

--- a/screenpy_playwright/actions/scroll.py
+++ b/screenpy_playwright/actions/scroll.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from screenpy import beat
+from playwright.sync_api import Error as PlaywrightError
+from screenpy import DeliveryError, beat
 
 from ..abilities import BrowseTheWebSynchronously
 
@@ -100,4 +101,11 @@ class Scroll:
     def perform_as(self, the_actor: Actor) -> None:
         """Direct the Actor to scroll the page."""
         page = the_actor.ability_to(BrowseTheWebSynchronously).current_page
-        page.mouse.wheel(delta_x=self.delta_x, delta_y=self.delta_y)
+        try:
+            page.mouse.wheel(delta_x=self.delta_x, delta_y=self.delta_y)
+        except PlaywrightError as e:
+            msg = (
+                f"{the_actor} encountered an issue while attempting to scroll "
+                f"{self.direction_to_log}: {e.__class__.__name__}"
+            )
+            raise DeliveryError(msg) from e

--- a/screenpy_playwright/actions/select.py
+++ b/screenpy_playwright/actions/select.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Sequence, TypedDict
 
-from screenpy import UnableToAct, beat
+from playwright.sync_api import Error as PlaywrightError
+from screenpy import DeliveryError, UnableToAct, beat
 
 if TYPE_CHECKING:
     from playwright.sync_api import ElementHandle
@@ -106,4 +107,11 @@ class Select:
             )
             raise UnableToAct(msg)
 
-        self.target.found_by(the_actor).select_option(self.args, **self.kwargs)
+        try:
+            self.target.found_by(the_actor).select_option(self.args, **self.kwargs)
+        except PlaywrightError as e:
+            msg = (
+                f"{the_actor} encountered an issue while attempting to select "
+                f"{self.target}: {e.__class__.__name__}"
+            )
+            raise DeliveryError(msg) from e

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -3,7 +3,8 @@ from typing import cast
 from unittest import mock
 
 import pytest
-from screenpy import Actor, Describable, Performable, UnableToAct
+from playwright.sync_api import Error as PlaywrightError
+from screenpy import Actor, DeliveryError, Describable, Performable, UnableToAct
 
 from screenpy_playwright import (
     BrowseTheWebSynchronously,
@@ -49,6 +50,13 @@ class TestClick:
 
         target.found_by.assert_called_once_with(Tester)
         locator.click.assert_called_once_with(delay=0.5)
+
+    def test_raises_deliveryerror(self, Tester: Actor) -> None:
+        target, locator = get_mocked_target_and_locator()
+        locator.click.side_effect = PlaywrightError("I have no more pens.")
+
+        with pytest.raises(DeliveryError):
+            Click(target).perform_as(Tester)
 
 
 class TestEnter:
@@ -99,6 +107,13 @@ class TestEnter:
         target.found_by.assert_called_once_with(Tester)
         locator.fill.assert_called_once_with(text, force=True)
 
+    def test_raises_deliveryerror(self, Tester: Actor) -> None:
+        target, locator = get_mocked_target_and_locator()
+        locator.fill.side_effect = PlaywrightError("I have no more ink.")
+
+        with pytest.raises(DeliveryError):
+            Enter("quietly").into_the(target).perform_as(Tester)
+
 
 class TestRefreshThePage:
     def test_can_be_instantiated(self) -> None:
@@ -124,6 +139,15 @@ class TestRefreshThePage:
         RefreshThePage(timeout=20).perform_as(Tester)
 
         current_page.reload.assert_called_once_with(timeout=20)
+
+    def test_raises_deliveryerror(self, Tester: Actor) -> None:
+        page = cast(
+            mock.Mock, Tester.ability_to(BrowseTheWebSynchronously).current_page
+        )
+        page.reload.side_effect = PlaywrightError("I have no more paper.")
+
+        with pytest.raises(DeliveryError):
+            RefreshThePage().perform_as(Tester)
 
 
 class TestSaveScreenshot:
@@ -190,6 +214,15 @@ class TestSaveScreenshot:
         assert isinstance(sss2, SubSaveScreenshot)
         assert isinstance(sss3, SubSaveScreenshot)
 
+    def test_raises_deliveryerror(self, Tester: Actor) -> None:
+        page = cast(
+            mock.Mock, Tester.ability_to(BrowseTheWebSynchronously).current_page
+        )
+        page.screenshot.side_effect = PlaywrightError("I have no camera.")
+
+        with pytest.raises(DeliveryError):
+            SaveScreenshot("./screenshot.png").perform_as(Tester)
+
 
 class TestScroll:
     def test_can_be_instantiated(self) -> None:
@@ -246,6 +279,15 @@ class TestScroll:
 
         current_page.mouse.wheel.assert_called_once_with(delta_x=1337, delta_y=-9001)
 
+    def test_raises_deliveryerror(self, Tester: Actor) -> None:
+        page = cast(
+            mock.Mock, Tester.ability_to(BrowseTheWebSynchronously).current_page
+        )
+        page.mouse.wheel.side_effect = PlaywrightError("I have no legs.")
+
+        with pytest.raises(DeliveryError):
+            Scroll(1337, -9001).perform_as(Tester)
+
 
 class TestSelect:
     def test_can_be_instantiated(self) -> None:
@@ -285,6 +327,13 @@ class TestSelect:
     def test_raises_with_no_target(self, Tester: Actor) -> None:
         with pytest.raises(UnableToAct):
             Select("option").perform_as(Tester)
+
+    def test_raises_deliveryerror(self, Tester: Actor) -> None:
+        target, locator = get_mocked_target_and_locator()
+        locator.select_option.side_effect = PlaywrightError("I have no opinions.")
+
+        with pytest.raises(DeliveryError):
+            Select("option").from_the(target).perform_as(Tester)
 
 
 class TestVisit:
@@ -334,3 +383,11 @@ class TestVisit:
         mock_page.goto.assert_called_once_with(url, wait_until="commit")
         assert mock_ability.current_page == mock_page
         assert mock_page in mock_ability.pages
+
+    def test_raises_deliveryerror(self, Tester: Actor) -> None:
+        browse_the_web = cast(mock.Mock, Tester.ability_to(BrowseTheWebSynchronously))
+        browse_the_web.browser.new_page.return_value = browse_the_web.current_page
+        browse_the_web.current_page.goto.side_effect = PlaywrightError("I have no map.")
+
+        with pytest.raises(DeliveryError):
+            Visit("url").perform_as(Tester)


### PR DESCRIPTION
Playwright has very verbose error messages. Which is nice! But we did all this work to make `Target` have a nice readable name, only to spit out the complicated Playwright locator while looking at the error log? No thanks.

This PR wraps all the Actions in a try/except which will show a helpful `DeliveryError` if Playwright encounters an error.