### PR TITLE
Reorganize methods.

### DIFF
--- a/screenpy_playwright/actions/click.py
+++ b/screenpy_playwright/actions/click.py
@@ -56,6 +56,10 @@ class Click:
 
     on = on_the
 
+    def __init__(self, target: Target, **kwargs: Unpack[ClickTypes]) -> None:
+        self.target = target
+        self.kwargs = kwargs
+
     def describe(self) -> str:
         """Describe the Action in present tense."""
         return f"Click on the {self.target}."
@@ -71,7 +75,3 @@ class Click:
                 f"{self.target}: {e.__class__.__name__}"
             )
             raise DeliveryError(msg) from e
-
-    def __init__(self, target: Target, **kwargs: Unpack[ClickTypes]) -> None:
-        self.target = target
-        self.kwargs = kwargs

--- a/screenpy_playwright/actions/enter.py
+++ b/screenpy_playwright/actions/enter.py
@@ -61,6 +61,18 @@ class Enter:
         """Alias for ``the_secret``, recreated for mypy."""
         return cls.the_secret(text, **kwargs)
 
+    def __init__(
+        self, text: str, *, mask: bool = False, **kwargs: Unpack[EnterTypes]
+    ) -> None:
+        self.text = text
+        self.target = None
+        self.kwargs = kwargs
+
+        if mask:
+            self.text_to_log = "[CENSORED]"
+        else:
+            self.text_to_log = text
+
     def into_the(self, target: Target, **kwargs: Unpack[EnterTypes]) -> Enter:
         """Target the element to enter text into.
 
@@ -95,15 +107,3 @@ class Enter:
                 f"{self.target}: {e.__class__.__name__}"
             )
             raise DeliveryError(msg) from e
-
-    def __init__(
-        self, text: str, *, mask: bool = False, **kwargs: Unpack[EnterTypes]
-    ) -> None:
-        self.text = text
-        self.target = None
-        self.kwargs = kwargs
-
-        if mask:
-            self.text_to_log = "[CENSORED]"
-        else:
-            self.text_to_log = text

--- a/screenpy_playwright/actions/open.py
+++ b/screenpy_playwright/actions/open.py
@@ -48,6 +48,13 @@ class Open:
 
     kwargs: OpenTypes
 
+    def __init__(self, location: str | PageObject, **kwargs: Unpack[OpenTypes]) -> None:
+        url = getattr(location, "url", location)
+        url = f'{os.getenv("BASE_URL", "")}{url}'
+
+        self.url = url
+        self.kwargs = kwargs
+
     def describe(self) -> str:
         """Describe the Action in present tense."""
         return f"Visit {self.url}"
@@ -65,10 +72,3 @@ class Open:
                 f"{self.url}: {e.__class__.__name__}"
             )
             raise DeliveryError(msg) from e
-
-    def __init__(self, location: str | PageObject, **kwargs: Unpack[OpenTypes]) -> None:
-        url = getattr(location, "url", location)
-        url = f'{os.getenv("BASE_URL", "")}{url}'
-
-        self.url = url
-        self.kwargs = kwargs

--- a/screenpy_playwright/actions/save_screenshot.py
+++ b/screenpy_playwright/actions/save_screenshot.py
@@ -49,10 +49,6 @@ class SaveScreenshot:
     path: str
     filename: str
 
-    def describe(self) -> str:
-        """Describe the Action in present tense."""
-        return f"Save screenshot as {self.filename}"
-
     @classmethod
     def as_(cls, path: str) -> Self:
         """Supply the name and/or filepath for the screenshot.
@@ -64,6 +60,15 @@ class SaveScreenshot:
             path: The filepath for the screenshot, including its name.
         """
         return cls(path=path)
+
+    def __init__(self, path: str) -> None:
+        self.path = path
+        self.filename = path.split(os.path.sep)[-1]
+        self.attach_kwargs = None
+
+    def describe(self) -> str:
+        """Describe the Action in present tense."""
+        return f"Save screenshot as {self.filename}"
 
     def and_attach_it(self, **kwargs: Any) -> Self:  # noqa: ANN401
         """Indicate the screenshot should be attached to any reports.
@@ -103,8 +108,3 @@ class SaveScreenshot:
 
         if self.attach_kwargs is not None:
             the_actor.attempts_to(AttachTheFile(self.path, **self.attach_kwargs))
-
-    def __init__(self, path: str) -> None:
-        self.path = path
-        self.filename = path.split(os.path.sep)[-1]
-        self.attach_kwargs = None

--- a/screenpy_playwright/questions/number.py
+++ b/screenpy_playwright/questions/number.py
@@ -32,6 +32,9 @@ class Number:
         """
         return Number(target)
 
+    def __init__(self, target: Target) -> None:
+        self.target = target
+
     def describe(self) -> str:
         """Describe the Question in the present tense.
 
@@ -48,6 +51,3 @@ class Number:
             The number of elements the Actor found.
         """
         return self.target.found_by(the_actor).count()
-
-    def __init__(self, target: Target) -> None:
-        self.target = target

--- a/screenpy_playwright/questions/text.py
+++ b/screenpy_playwright/questions/text.py
@@ -34,6 +34,9 @@ class Text:
         """
         return Text(target)
 
+    def __init__(self, target: Target) -> None:
+        self.target = target
+
     def describe(self) -> str:
         """Describe the Question in the present tense.
 
@@ -50,6 +53,3 @@ class Text:
             The text found by the Actor.
         """
         return self.target.found_by(the_actor).text_content()
-
-    def __init__(self, target: Target) -> None:
-        self.target = target


### PR DESCRIPTION
This has been buggin' me for a while—i've started to write classes such that the `__init__` appears between the classmethods and the instance methods. To me, that very nicely visually marks where class/static methods end and instance methods begin.

This should not affect functionality at all, just a little apple skin stuck in my craw.